### PR TITLE
Update blog query:: allow Boolean operators 

### DIFF
--- a/config/db/index.js
+++ b/config/db/index.js
@@ -1,4 +1,4 @@
-const logSQL = true
+const logSQL = false
 const initOptions = {
 	query(e) {
 		if (logSQL) console.log(e.query)

--- a/config/edit/index.js
+++ b/config/edit/index.js
@@ -9,9 +9,9 @@ exports.app_description = require('./translations.js').translations['app descrip
 
 // apps_in_suite NEED TO BE THE NAMES OF THE DIFFERENT DBs
 exports.apps_in_suite = [
-	{ name: 'Action Plans', key: process.env.NODE_ENV === 'production' ? 'action_plans_platform' : (process.env.DB_AP || 'ap_test_02'), baseurl: 'https://acclabs-actionlearningplans.azurewebsites.net/' },
-	{ name: 'Solutions Mapping', key: process.env.NODE_ENV === 'production' ? 'solutions_mapping_platform' : (process.env.DB_SM || 'sm_test_02'), baseurl: 'https://acclabs-solutionsmapping.azurewebsites.net/' },
-	{ name: 'Experiments', key: process.env.NODE_ENV === 'production' ? 'experiments_platform' : (process.env.DB_EXP || 'exp_test_02'), baseurl: 'https://acclabs-experiments.azurewebsites.net/' }
+	{ name: 'Action Plans', key: process.env.NODE_ENV === 'production' ? 'action_plans_platform' : (process.env.DB_AP || 'solutions_mapping_platform'), baseurl: 'https://acclabs-actionlearningplans.azurewebsites.net/' },
+	{ name: 'Solutions Mapping', key: process.env.NODE_ENV === 'production' ? 'solutions_mapping_platform' : (process.env.DB_SM || 'solutions_mapping_platform'), baseurl: 'https://acclabs-solutionsmapping.azurewebsites.net/' },
+	{ name: 'Experiments', key: process.env.NODE_ENV === 'production' ? 'experiments_platform' : (process.env.DB_EXP || 'solutions_mapping_platform'), baseurl: 'https://acclabs-experiments.azurewebsites.net/' }
 	// { name: 'Blogs', key: 'exp_test_02', baseurl: 'https://acclabs-blogs.azurewebsites.net/' },
 	// { name: 'Consent archive', key: 'exp_test_02', baseurl: 'https://acclabs-consent-archive.azurewebsites.net/' },
 	// { name: 'Buzz', key: 'exp_test_02', baseurl: 'https://acclabs-buzz.azurewebsites.net/' },

--- a/routes/browse/blog/searchBlogs.js
+++ b/routes/browse/blog/searchBlogs.js
@@ -1,4 +1,5 @@
 const { searchBlogQuery } = require('./query')
+const { parsers } = include('routes/helpers/')
 
 exports.main = async kwargs => {
 	const conn = kwargs.connection ? kwargs.connection : DB.conn
@@ -6,11 +7,22 @@ exports.main = async kwargs => {
 
     const searchText = req.query.search ||  '';
 	let { source, search, country, type } = req.query || {}
+	const searchRegex = searchText ? parsers.regexQuery(searchText) : '';
 
 	return conn.task(t => {
 			return t.any(searchBlogQuery(searchText, page, country, type)).then(async (results) => {
+				// console.log('searchRegex ', searchRegex)
+				// Process each row and collect results
+				const res = results.map((row) => {
+					const matchedTexts = extractContext(row.content, searchRegex);
+					delete row.content
+					delete row.all_html_content
+					// console.log('matchedTexts ', matchedTexts)
+					return { ...row, matched_texts: matchedTexts };
+				});
+
 				return {
-					searchResults : results,
+					searchResults : res,
 					page,
 					total_pages : results[0]?.total_pages || 0,
 					totalRecords : results[0]?.total_records || 0
@@ -26,3 +38,90 @@ exports.main = async kwargs => {
 		
 	})
 }
+
+function extractContext(text, searchTerm) {
+    const regexPattern = sanitizeSearchTerm(searchTerm);
+    const match = text.match(regexPattern);
+	const words = text.split(/\s+/);
+
+	let wordIndex = 0;
+	let charCount = 0;
+	const startIndex = Math.max(0, wordIndex - 10);
+    const endIndex = Math.min(words.length, wordIndex + 100);
+
+    if (match) {
+        // Find the index of the word where the match starts
+        while (charCount < match.index) {
+            charCount += words[wordIndex].length + 1; // +1 for space
+            wordIndex++;
+        }
+    }
+
+	const contextBefore = words.slice(startIndex, wordIndex).join(' ');
+	const contextAfter = words.slice(wordIndex, endIndex).join(' ');
+	return contextBefore + ' ' + contextAfter;
+}
+
+
+function sanitizeSearchTerm(searchTerm) {
+    // Split the search term into individual words or phrases
+    const terms = searchTerm.split('|');
+
+    // Sanitize each word or phrase
+    const sanitizedTerms = terms.map(term => {
+        // Remove invalid escape characters
+        const termWithoutInvalidEscapes = term.replace(/\\(?![b])/g, '');
+        
+        // Replace \m and \M with \b
+        return termWithoutInvalidEscapes.replace(/m|M/g, '\\b');
+    });
+
+    // Join the sanitized words or phrases back into a single string
+    const sanitizedSearchTerm = sanitizedTerms.join('|');
+    
+    // Create regular expression
+    const regexPattern = new RegExp(`${sanitizedSearchTerm}`, 'i');
+    return regexPattern;
+}
+
+
+
+
+
+ const documents = _data => {
+	const { embeddings, documents, filters, language } = _data
+
+	let b = '\\b' // WORD BOUNDARIES
+	let B = '\\B'
+	if (language === 'AR') {
+		b = '(^|[^\u0621-\u064A])'
+		B = '($|[^\u0621-\u064A])'
+	}
+
+	let terms = []
+	if (embeddings) terms = embeddings.flat().unique().filter(d => d.charAt(0) !== '-')
+	let filteredTerms = []
+	if (filters) filteredTerms = filters.flat().unique().filter(d => d.charAt(0) !== '-')
+	
+	return documents.map(d => {
+		d.matches = []
+		terms.forEach(c => {
+			let match
+			if (c.indexOf('*') !== -1) match = d.text.match(new RegExp(`${b}(\#)?${c.trim()}(\\w+)?`, 'gi'))
+			else match = d.text.match(new RegExp(`${b}(\#)?${c.trim()}(\\S+)?`, 'gi'))
+			if (match) match.unique().forEach(b => d.text = d.text.replace(b, `<span class='highlight-term'>${b}</span>`))
+			d.matches.push({ term: c, count: (match || []).length })
+		})
+		filteredTerms.forEach(c => {
+			let match
+			if (c.indexOf('*') !== -1) match = d.text.match(new RegExp(`${b}(\#)?${c.trim()}(\\w+)?`, 'gi'))
+			else match = d.text.match(new RegExp(`${b}(\#)?${c.trim()}(\\S+)?`, 'gi'))
+			if (match) match.forEach(b => d.text = d.text.replace(b, `<span class='highlight-filtered-term'>${b}</span>`))
+		})
+		if (d.tags) d.tags = d.tags.map(c => JSON.parse(c))
+		return d
+	})
+}
+  
+
+  

--- a/views/browse/blogs/index.ejs
+++ b/views/browse/blogs/index.ejs
@@ -152,31 +152,7 @@
 								  </div>
 								  <div class="media media-txt" style="margin-top: 20px; white-space: inherit !important;">
 									<a class="pad-link" target="_blank" style="width: 100% !important; ">
-										<%
-										  function findMatchingText(largeText) {
-
-											largeText.trim().replace(/^\n+|\n+$/g, '');
-
-											var searchText = locals?.metadata?.page?.query?.['search'] || ""
-
-											var escapedSearchText = searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-											var pattern = new RegExp(`[^.!?]*${escapedSearchText}[^.!?]*[.!?]`, 'g');
-											var matches = largeText.match(pattern);
-
-											if (matches && matches.length > 0) {
-											  var firstSentence = matches[0];
-											  var secondSentence = matches[1];
-											  var lastSentence = matches[matches.length - 1];
-											  return firstSentence + " " + `${secondSentence || ''}`;
-											} else {
-											  return largeText?.split(' ')?.slice(0, 100)?.join(' ') || null;
-											}
-										  }
-
-										  var extractedText = findMatchingText(result?.content || result?.all_html_content || '');
-										%>
-
-										<%= extractedText || 'We are unable to extract content from the original website. Please click to read content on the original website.' %> ... <a target="_blank" href="<%= result.url %>" style="cursor: pointer; color: cornflowerblue;">read more</a>
+										<%= result?.matched_texts || 'We are unable to extract content from the original website. Please click to read content on the original website.' %> ... <a target="_blank" href="<%= result.url %>" style="cursor: pointer; color: cornflowerblue;">read more</a>
 									  </a>
 								  </div>
 								  <div class="meta tag-group">


### PR DESCRIPTION
The main purpose of this PR is to enable users to search for multiple blog search phrases and utilize Boolean operators similar to pad/template searches.

- [x] Utilize the helper function  `parsers.regexQuery`  to format boolean operator searches.

- [x] Retrieve sentences that match the user's search from the blog record. If no search query is provided, return the first two sentences.